### PR TITLE
Update README example `uses` statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Nix
-      uses: DeterminateSystems/nix-installer-action
+      uses: DeterminateSystems/nix-installer-action@main
       with:
         # Allow the installed Nix to make authenticated Github requests.
         # If you skip this, you will likely get rate limited.


### PR DESCRIPTION
Somehow omitting `@main` from the `uses` statement makes the reference to the Action invalid as I learned in the [Z2N repo](https://github.com/determinatesystems/zero-to-nix):

https://github.com/DeterminateSystems/zero-to-nix/actions/runs/3940423934

Apparently it needs to be a Docker image, a path, or `{owner}/{repo}@{ref}`.
