### PR TITLE
Make the runner user trusted by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
           reinstall: true
+          extra-conf: |
+            use-sqlite-wal = true
       - name: Test `nix` with `$GITHUB_PATH`
         if: success() || failure()
         run: |
@@ -71,6 +73,7 @@ jobs:
         run: |
           cat -n /etc/nix/nix.conf
           grep -E "^trusted-users = .*$USER" /etc/nix/nix.conf
+          grep -E "^use-sqlite-wal = true" /etc/nix/nix.conf
 
   run-x86_64-darwin:
     name: Run x86_64 Darwin
@@ -129,6 +132,8 @@ jobs:
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
           reinstall: true
+          extra-conf: |
+            use-sqlite-wal = true
       - name: Test `nix` with `$GITHUB_PATH`
         if: success() || failure()
         run: |
@@ -141,3 +146,4 @@ jobs:
         run: |
           cat -n /etc/nix/nix.conf
           grep -E "^trusted-users = .*$USER" /etc/nix/nix.conf
+          grep -E "^use-sqlite-wal = true" /etc/nix/nix.conf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,10 @@ jobs:
           fortune
           nix store gc
           nix run nixpkgs#fortune
+      - name: Verify the generated nix.conf
+        run: |
+          cat -n /etc/nix/nix.conf
+          grep -E "^trusted-users = .*$USER" /etc/nix/nix.conf
 
   run-x86_64-darwin:
     name: Run x86_64 Darwin
@@ -133,3 +137,7 @@ jobs:
           fortune
           nix store gc
           nix run nixpkgs#fortune
+      - name: Verify the generated nix.conf
+        run: |
+          cat -n /etc/nix/nix.conf
+          grep -E "^trusted-users = .*$USER" /etc/nix/nix.conf

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   github-token:
     description: A GitHub Token for making authenticated requests (which have a higher rate-limit quota than unauthenticated requests)
     default: ${{ github.token }}
+  trust-runner-user:
+    description: Whether to make the runner user trusted by the Nix daemon
+    default: "true"
   channels:
     description: Channel(s) to add (eg `nixpkgs=https://nixos.org/channels/nixpkgs-unstable`)
     required: false
@@ -160,18 +163,21 @@ runs:
           echo "Set NIX_INSTALLER_NIX_PACKAGE_URL=$NIX_INSTALLER_NIX_PACKAGE_URL"
         fi
 
+        NIX_EXTRA_CONF=""
+        NEWLINE='
+        '
         if [ -n "${{ inputs.extra-conf }}" ]; then
-          if [ -n "${{ inputs.github-token }}" ]; then
-            export NIX_INSTALLER_EXTRA_CONF="${{ inputs.extra-conf }}access-tokens = github.com=${{ inputs.github-token }}"
-          else
-            export NIX_INSTALLER_EXTRA_CONF="${{ inputs.extra-conf }}"
-          fi
+          NIX_EXTRA_CONF="${{ inputs.extra-conf }}"
+        fi
+        if [ -n "${{ inputs.github-token }}" ]; then
+          NIX_EXTRA_CONF="${NIX_EXTRA_CONF:+$NIX_EXTRA_CONF$NEWLINE}access-tokens = github.com=${{ inputs.github-token }}"
+        fi
+        if [ "${{ inputs.trust-runner-user }}" == "true" ]; then
+          NIX_EXTRA_CONF="${NIX_EXTRA_CONF:+$NIX_EXTRA_CONF$NEWLINE}trusted-users = root $USER"
+        fi
+        if [ -n "$NIX_EXTRA_CONF" ]; then
+          export NIX_INSTALLER_EXTRA_CONF="$NIX_EXTRA_CONF"
           echo "Set NIX_INSTALLER_EXTRA_CONF=$NIX_INSTALLER_EXTRA_CONF"
-        else
-          if [ -n "${{ inputs.github-token }}" ]; then
-            export NIX_INSTALLER_EXTRA_CONF="access-tokens = github.com=${{ inputs.github-token }}"
-            echo "Set NIX_INSTALLER_EXTRA_CONF=$NIX_INSTALLER_EXTRA_CONF"
-          fi
         fi
 
         if [ -n "${{ inputs.mac-encrypt }}" ]; then


### PR DESCRIPTION
Usually we want the runner user to be able to configure binary caches.