### PR TITLE
Add default value for the the github-token input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,8 @@ inputs:
     description: Extra args to pass to the planner (prefer using structured `with:` arguments unless using a custom planner!)
     required: false
   github-token:
-    description: A Github Token so that authenticated requests can be made (set this to `secrets.GITHUB_TOKEN`)
+    description: A GitHub Token for making authenticated requests (which have a higher rate-limit quota than unauthenticated requests)
+    default: ${{ github.token }}
   channels:
     description: Channel(s) to add (eg `nixpkgs=https://nixos.org/channels/nixpkgs-unstable`)
     required: false


### PR DESCRIPTION
Since you are likely to be rate-limited if you use this action
without a GitHub API token, default the action's `github-token` input
to the `token` from the `github` context[^1].

Closes #3

[^1]: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context