### PR TITLE
Clarify options which require a specific planner

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,16 +41,16 @@ inputs:
     description: Extra configuration lines for `/etc/nix.conf` (includes `access-tokens` with `secrets.GITHUB_TOKEN` automatically if `github-token` is set)
     required: false
   mac-encrypt:
-    description: Force encryption on the volume (Mac only)
+    description: "Force encryption on the volume (`planner: macos` only)"
     required: false
   mac-case-sensitive:
-    description: Use a case sensitive volume (Mac only)
+    description: "Use a case sensitive volume (`planner: macos` only)"
     required: false
   mac-volume-label:
-    description: The label for the created APFS volume (Mac only)
+    description: "The label for the created APFS volume (`planner: macos` only)"
     required: false
   mac-root-disk:
-    description: The root disk of the target (Mac only)
+    description: "The root disk of the target (`planner: macos` only)"
     required: false
   nix-installer-url:
     description: A URL pointing to a `nix-installer.sh` script


### PR DESCRIPTION
Some Mac options required users to actually manually select that planner.

We can improve this later, but for now, this is necessary.