### PR TITLE
Add a ?ci=github to GHA requests

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -255,18 +255,18 @@ runs:
           echo "Set NIX_INSTALLER_FORCE_ALLOW_HTTP=$NIX_INSTALLER_FORCE_ALLOW_HTTP"
         else
           if [ -n "${{ inputs.nix-installer-url }}" ]; then
-            export NIX_INSTALLER_URL=${{ inputs.nix-installer-url }}
+            export NIX_INSTALLER_URL="${{ inputs.nix-installer-url }}"
           else
             if [ -n "${{ inputs.nix-installer-pr }}" ]; then
-              export NIX_INSTALLER_URL=https://install.determinate.systems/nix/pr/${{ inputs.nix-installer-pr }}?ci=github
+              export NIX_INSTALLER_URL="https://install.determinate.systems/nix/pr/${{ inputs.nix-installer-pr }}?ci=github"
             elif [ -n "${{ inputs.nix-installer-tag }}" ]; then
-              export NIX_INSTALLER_URL=https://install.determinate.systems/nix/tag/${{ inputs.nix-installer-tag }}?ci=github
+              export NIX_INSTALLER_URL="https://install.determinate.systems/nix/tag/${{ inputs.nix-installer-tag }}?ci=github"
             elif [ -n "${{ inputs.nix-installer-revision }}" ]; then
-              export NIX_INSTALLER_URL=https://install.determinate.systems/nix/rev/${{ inputs.nix-installer-revision }}?ci=github
+              export NIX_INSTALLER_URL="https://install.determinate.systems/nix/rev/${{ inputs.nix-installer-revision }}?ci=github"
             elif [ -n "${{ inputs.nix-installer-branch }}" ]; then
-              export NIX_INSTALLER_URL=https://install.determinate.systems/nix/branch/${{ inputs.nix-installer-branch }}?ci=github
+              export NIX_INSTALLER_URL="https://install.determinate.systems/nix/branch/${{ inputs.nix-installer-branch }}?ci=github"
             else
-              export NIX_INSTALLER_URL=https://install.determinate.systems/nix?ci=github
+              export NIX_INSTALLER_URL="https://install.determinate.systems/nix?ci=github"
             fi
           fi
           echo "Set NIX_INSTALLER_URL=$NIX_INSTALLER_URL"

--- a/action.yml
+++ b/action.yml
@@ -258,15 +258,15 @@ runs:
             export NIX_INSTALLER_URL=${{ inputs.nix-installer-url }}
           else
             if [ -n "${{ inputs.nix-installer-pr }}" ]; then
-              export NIX_INSTALLER_URL=https://install.determinate.systems/nix/pr/${{ inputs.nix-installer-pr }}
+              export NIX_INSTALLER_URL=https://install.determinate.systems/nix/pr/${{ inputs.nix-installer-pr }}?ci=github
             elif [ -n "${{ inputs.nix-installer-tag }}" ]; then
-              export NIX_INSTALLER_URL=https://install.determinate.systems/nix/tag/${{ inputs.nix-installer-tag }}
+              export NIX_INSTALLER_URL=https://install.determinate.systems/nix/tag/${{ inputs.nix-installer-tag }}?ci=github
             elif [ -n "${{ inputs.nix-installer-revision }}" ]; then
-              export NIX_INSTALLER_URL=https://install.determinate.systems/nix/rev/${{ inputs.nix-installer-revision }}
+              export NIX_INSTALLER_URL=https://install.determinate.systems/nix/rev/${{ inputs.nix-installer-revision }}?ci=github
             elif [ -n "${{ inputs.nix-installer-branch }}" ]; then
-              export NIX_INSTALLER_URL=https://install.determinate.systems/nix/branch/${{ inputs.nix-installer-branch }}
+              export NIX_INSTALLER_URL=https://install.determinate.systems/nix/branch/${{ inputs.nix-installer-branch }}?ci=github
             else
-              export NIX_INSTALLER_URL=https://install.determinate.systems/nix
+              export NIX_INSTALLER_URL=https://install.determinate.systems/nix?ci=github
             fi
           fi
           echo "Set NIX_INSTALLER_URL=$NIX_INSTALLER_URL"


### PR DESCRIPTION
##### Description

Add a `?ci=github` to our auto generated URLs. This will allow us to provide Github Actions with binaries which may be slightly more recent than normal requests, since Github Actions exist within a much more controlled environment.

##### Checklist

- [ ] Tested changes against a test repository
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] (If this PR is for a release) Updated README to point to the new tag (leave unchecked if not applicable)
