### PR TITLE
main.ts: fixup logic to ensure only one installer url override is set

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -597,25 +597,30 @@ function resolve_nix_installer_url(
     resolved_nix_installer_url = new URL(
       `https://install.determinate.systems/nix/branch/${nix_installer_branch}/nix-installer-${platform}?${url_suffix}`,
     );
-  } else if (nix_installer_pr !== null) {
+  }
+  if (nix_installer_pr !== null) {
     num_set += 1;
     resolved_nix_installer_url = new URL(
       `https://install.determinate.systems/nix/pr/${nix_installer_pr}/nix-installer-${platform}?${url_suffix}`,
     );
-  } else if (nix_installer_revision !== null) {
+  }
+  if (nix_installer_revision !== null) {
     num_set += 1;
     resolved_nix_installer_url = new URL(
       `https://install.determinate.systems/nix/rev/${nix_installer_revision}/nix-installer-${platform}?${url_suffix}`,
     );
-  } else if (nix_installer_tag !== null) {
+  }
+  if (nix_installer_tag !== null) {
     num_set += 1;
     resolved_nix_installer_url = new URL(
       `https://install.determinate.systems/nix/tag/${nix_installer_tag}/nix-installer-${platform}?${url_suffix}`,
     );
-  } else if (nix_installer_url !== null) {
+  }
+  if (nix_installer_url !== null) {
     num_set += 1;
     resolved_nix_installer_url = new URL(nix_installer_url);
-  } else {
+  }
+  if (resolved_nix_installer_url == null) {
     resolved_nix_installer_url = new URL(
       `https://install.determinate.systems/nix/nix-installer-${platform}?${url_suffix}`,
     );


### PR DESCRIPTION
##### Description

* the use of `else if` would have made the "counting" of the url modifiers useless, so switch them to ifs.
* correspondingly, update the fallthrough `else` condition to set the URL if no modifiers were passed to override it

##### Checklist

- [x] Tested changes against a test repository
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] (If this PR is for a release) Updated README to point to the new tag (leave unchecked if not applicable)
