### PR TITLE
Fix broken CI caused by Nix reinstallation wiping out the Magic Nix Cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,13 +172,15 @@ jobs:
         if: success() || failure()
         run: |
           pkill magic-nix-cache
+      - name: Uninstall Nix
+        run: |
+          /nix/nix-installer uninstall --no-confirm
       - name: Reinstall Nix
         uses: ./
         with:
           logger: pretty
           log-directives: nix_installer=trace
           backtrace: full
-          reinstall: true
           extra-conf: |
             use-sqlite-wal = true
       - name: Test `nix` with `$GITHUB_PATH`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
           logger: pretty
           log-directives: nix_installer=trace
           backtrace: full
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: echo $PATH
         run: echo $PATH
 
@@ -131,7 +130,6 @@ jobs:
           logger: pretty
           log-directives: nix_installer=trace
           backtrace: full
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: echo $PATH
         run: echo $PATH
       - name: Test `nix` with `$GITHUB_PATH`
@@ -168,12 +166,6 @@ jobs:
           hello
           nix store gc
           nix run nixpkgs#hello
-      - name: Terminate the magic nix cache pre-reinstall
-        if: success() || failure()
-        run: |
-          pkill magic-nix-cache
-      # Reinstate the MNC
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Reinstall Nix
         uses: ./
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,9 @@ jobs:
           hello
           nix store gc
           nix run nixpkgs#hello
+      - name: Uninstall Nix
+        run: |
+          /nix/nix-installer uninstall --no-confirm
       - name: Reinstall Nix
         uses: ./
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,15 +88,13 @@ jobs:
           hello
           nix store gc
           nix run nixpkgs#hello
-      - name: Uninstall Nix
-        run: |
-          /nix/nix-installer uninstall --no-confirm
       - name: Reinstall Nix
         uses: ./
         with:
           logger: pretty
           log-directives: nix_installer=trace
           backtrace: full
+          reinstall: true
           extra-conf: |
             use-sqlite-wal = true
       - name: Test `nix` with `$GITHUB_PATH`
@@ -174,15 +172,15 @@ jobs:
         if: success() || failure()
         run: |
           pkill magic-nix-cache
-      - name: Uninstall Nix
-        run: |
-          /nix/nix-installer uninstall --no-confirm
+      # Reinstate the MNC
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Reinstall Nix
         uses: ./
         with:
           logger: pretty
           log-directives: nix_installer=trace
           backtrace: full
+          reinstall: true
           extra-conf: |
             use-sqlite-wal = true
       - name: Test `nix` with `$GITHUB_PATH`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,6 @@ jobs:
           logger: pretty
           log-directives: nix_installer=trace
           backtrace: full
-          reinstall: true
           extra-conf: |
             use-sqlite-wal = true
       - name: Test `nix` with `$GITHUB_PATH`


### PR DESCRIPTION
The Magic Nix Cache isn't really necessary in the test suite so we're removing it, as reinstalling Nix wipes out the Nix store and thus the MNC executable. It'd be nice to concoct a nice way to test these two things side by side but that's an exercise best left for a future day.