### PR TITLE
Update action.yml description for source-url

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# https://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.github/verify-version.sh
+++ b/.github/verify-version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env
+
+EXPECTED_VERSION="${1}"
+
+NIX_VERSION_OUTPUT=$(nix --version)
+NIX_VERSION=$(echo "${NIX_VERSION_OUTPUT}" | awk '{print $NF}')
+EXPECTED_OUTPUT="nix (Nix) ${EXPECTED_VERSION}"
+if [ "${NIX_VERSION_OUTPUT}" != "${EXPECTED_OUTPUT}" ]; then
+  echo "Nix version ${NIX_VERSION} didn't match expected version ${EXPECTED_VERSION}"
+  exit 1
+else
+  echo "Success! Nix version ${NIX_VERSION} installed as expected"
+fi

--- a/.github/verify-version.sh
+++ b/.github/verify-version.sh
@@ -1,13 +1,18 @@
-#!/usr/bin/env
+#!/usr/bin/env bash
+
+# This script verifies that the version of Nix installed on the runner
+# matches the version supplied in the first argument.
 
 EXPECTED_VERSION="${1}"
 
-NIX_VERSION_OUTPUT=$(nix --version)
-NIX_VERSION=$(echo "${NIX_VERSION_OUTPUT}" | awk '{print $NF}')
+INSTALLED_NIX_VERSION_OUTPUT=$(nix --version)
+INSTALLED_NIX_VERSION=$(echo "${INSTALLED_NIX_VERSION_OUTPUT}" | awk '{print $NF}')
 EXPECTED_OUTPUT="nix (Nix) ${EXPECTED_VERSION}"
-if [ "${NIX_VERSION_OUTPUT}" != "${EXPECTED_OUTPUT}" ]; then
-  echo "Nix version ${NIX_VERSION} didn't match expected version ${EXPECTED_VERSION}"
+
+if [ "${INSTALLED_NIX_VERSION_OUTPUT}" != "${EXPECTED_OUTPUT}" ]; then
+  echo "Nix version ${INSTALLED_NIX_VERSION} didn't match expected version ${EXPECTED_VERSION}"
   exit 1
 else
-  echo "Success! Nix version ${NIX_VERSION} installed as expected"
+  echo "Success! Nix version ${INSTALLED_NIX_VERSION} installed as expected"
+  exit 0
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,14 +217,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install with alternative source-url
-        uses: ./.
+        uses: ./
         with:
           source-url: https://github.com/DeterminateSystems/nix-installer/releases/download/v0.18.0/nix-installer-x86_64-linux
       - name: Ensure that Nix is installed via alternative source-url
         run: nix --version
 
       - name: Install with alternative source-pr
-        uses: ./.
+        uses: ./
         with:
           # https://github.com/DeterminateSystems/nix-installer/pull/938
           source-pr: "938"
@@ -232,7 +232,7 @@ jobs:
         run: nix --version
 
       - name: Install with alternative source-revision
-        uses: ./.
+        uses: ./
         with:
           # https://github.com/DeterminateSystems/nix-installer/tree/ccf1d39a83099657ad324e7927676432435431e1
           source-revision: "ccf1d39a83099657ad324e7927676432435431e1"
@@ -240,7 +240,7 @@ jobs:
         run: nix --version
 
       - name: Install with alternative source-branch
-        uses: ./.
+        uses: ./
         with:
           # https://github.com/DeterminateSystems/nix-installer/tree/lazy-trees
           source-revision: "lazy-trees"
@@ -248,7 +248,7 @@ jobs:
         run: nix --version
 
       - name: Install with alternative source-tag
-        uses: ./.
+        uses: ./
         with:
           # https://github.com/DeterminateSystems/nix-installer/tree/v0.14.0
           source-tag: "v0.14.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,18 +212,25 @@ jobs:
           duration: 5m
           authorized-users: grahamc
 
-  install-with-non-default-inputs:
-    name: Install Nix using non-default Action inputs
+  install-with-non-default-source-url:
+    name: Install Nix using non-default source-url inputs
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        version:
-          - "0.12.0"
-          - "0.14.0"
-          - "0.19.0"
+        versions:
+          - { nix-installer: "0.12.0", nix: "2.20.0" }
+          - { nix-installer: "0.14.0", nix: "2.20.0" }
+          - { nix-installer: "0.18.0", nix: "2.20.0" }
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
         with:
-          source-url: https://github.com/DeterminateSystems/nix-installer/releases/download/v${{ matrix.version }}/nix-installer-x86_64-linux
-      - run: nix --version
+          source-url: https://github.com/DeterminateSystems/nix-installer/releases/download/v${{ matrix.versions.nix-installer }}/nix-installer-x86_64-linux
+      - run: |
+          NIX_VERSION_OUTPUT=$(nix --version)
+          NIX_VERSION=$(echo "{NIX_VERSION}" | awk '{print $NF}')
+          EXPECTED_OUTPUT="nix (Nix) ${{ matrix.versions.nix }}"
+          if [ "${NIX_VERSION_OUTPUT}" != "${EXPECTED_OUTPUT}" ]; then
+            echo "Nix version ${NIX_VERSION} didn't match expected version ${{ matrix.versions.nix }}"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,37 +222,37 @@ jobs:
         uses: ./
         with:
           source-url: https://github.com/DeterminateSystems/nix-installer/releases/download/v0.18.0/nix-installer-x86_64-linux
-      - name: Ensure that Nix is installed via alternative source-url
-        run: nix --version
+      - name: Ensure that the expected Nix version is installed via alternative source-url
+        run: .github/verify-version.sh 2.18.0
 
       - name: Install with alternative source-pr
         uses: ./
         with:
           # https://github.com/DeterminateSystems/nix-installer/pull/938
           source-pr: "938"
-      - name: Ensure that Nix is installed via alternative source-pr
-        run: nix --version
+      - name: Ensure that the expected Nix version is installed via alternative source-pr
+        run: .github/verify-version.sh 2.21.2
 
       - name: Install with alternative source-revision
         uses: ./
         with:
           # https://github.com/DeterminateSystems/nix-installer/tree/ccf1d39a83099657ad324e7927676432435431e1
           source-revision: "ccf1d39a83099657ad324e7927676432435431e1"
-      - name: Ensure that Nix is installed via alternative source-revision
-        run: nix --version
+      - name: Ensure that the expected Nix version is installed via alternative source-revision
+        run: .github/verify-version.sh 2.21.2
 
       - name: Install with alternative source-branch
         uses: ./
         with:
           # https://github.com/DeterminateSystems/nix-installer/tree/lazy-trees
           source-revision: "lazy-trees"
-      - name: Ensure that Nix is installed via alternative source-branch
-        run: nix --version
+      - name: Ensure that the expected Nix version is installed via alternative source-branch
+        run: .github/verify-version.sh 2.21.2
 
       - name: Install with alternative source-tag
         uses: ./
         with:
           # https://github.com/DeterminateSystems/nix-installer/tree/v0.14.0
           source-tag: "v0.14.0"
-      - name: Ensure that Nix is installed via alternative source-tag
-        run: nix --version
+      - name: Ensure that the expected Nix version is installed via alternative source-tag
+        run: .github/verify-version.sh 2.18.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,8 +212,8 @@ jobs:
           duration: 5m
           authorized-users: grahamc
 
-  install-with-non-default-source-url:
-    name: Install Nix using non-default source-url inputs
+  install-with-non-default-source-inputs:
+    name: Install Nix using non-default source-* inputs
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,15 +223,15 @@ jobs:
         with:
           source-url: https://github.com/DeterminateSystems/nix-installer/releases/download/v0.18.0/nix-installer-x86_64-linux
       - name: Ensure that the expected Nix version is installed via alternative source-url
-        run: .github/verify-version.sh 2.18.0
+        run: .github/verify-version.sh 2.21.2
 
       - name: Install with alternative source-pr
         uses: ./
         with:
-          # https://github.com/DeterminateSystems/nix-installer/pull/938
-          source-pr: "938"
+          # https://github.com/DeterminateSystems/nix-installer/pull/665
+          source-pr: "665"
       - name: Ensure that the expected Nix version is installed via alternative source-pr
-        run: .github/verify-version.sh 2.21.2
+        run: .github/verify-version.sh 2.18.0
 
       - name: Install with alternative source-revision
         uses: ./

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,23 +217,14 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        versions:
-          - { nix-installer: "0.12.0", nix: "2.18.0" }
-          - { nix-installer: "0.14.0", nix: "2.18.1" }
-          - { nix-installer: "0.18.0", nix: "2.20.0" }
+        version:
+          - "0.12.0"
+          - "0.14.0"
+          - "0.18.0"
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
         with:
-          source-url: https://github.com/DeterminateSystems/nix-installer/releases/download/v${{ matrix.versions.nix-installer }}/nix-installer-x86_64-linux
-      - name: Compare Nix version with expected version
-        run: |
-          NIX_VERSION_OUTPUT=$(nix --version)
-          NIX_VERSION=$(echo "${NIX_VERSION_OUTPUT}" | awk '{print $NF}')
-          EXPECTED_OUTPUT="nix (Nix) ${{ matrix.versions.nix }}"
-          if [ "${NIX_VERSION_OUTPUT}" != "${EXPECTED_OUTPUT}" ]; then
-            echo "Nix version ${NIX_VERSION} didn't match expected version ${{ matrix.versions.nix }}"
-            exit 1
-          else
-            echo "Success! Nix version ${NIX_VERSION} installed as expected"
-          fi
+          source-url: https://github.com/DeterminateSystems/nix-installer/releases/download/v${{ matrix.version }}/nix-installer-x86_64-linux
+      - name: Ensure that Nix is installed
+        run: nix --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,8 +218,8 @@ jobs:
     strategy:
       matrix:
         version:
-          - "0.17.0"
-          - "0.18.0"
+          - "0.12.0"
+          - "0.14.0"
           - "0.19.0"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,16 +215,42 @@ jobs:
   install-with-non-default-source-url:
     name: Install Nix using non-default source-url inputs
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        version:
-          - "0.12.0"
-          - "0.14.0"
-          - "0.18.0"
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
+      - name: Install with alternative source-url
+        uses: ./.
         with:
-          source-url: https://github.com/DeterminateSystems/nix-installer/releases/download/v${{ matrix.version }}/nix-installer-x86_64-linux
-      - name: Ensure that Nix is installed
+          source-url: https://github.com/DeterminateSystems/nix-installer/releases/download/v0.18.0/nix-installer-x86_64-linux
+      - name: Ensure that Nix is installed via alternative source-url
+        run: nix --version
+
+      - name: Install with alternative source-pr
+        uses: ./.
+        with:
+          # https://github.com/DeterminateSystems/nix-installer/pull/938
+          source-pr: "938"
+      - name: Ensure that Nix is installed via alternative source-pr
+        run: nix --version
+
+      - name: Install with alternative source-revision
+        uses: ./.
+        with:
+          # https://github.com/DeterminateSystems/nix-installer/tree/ccf1d39a83099657ad324e7927676432435431e1
+          source-revision: "ccf1d39a83099657ad324e7927676432435431e1"
+      - name: Ensure that Nix is installed via alternative source-revision
+        run: nix --version
+
+      - name: Install with alternative source-branch
+        uses: ./.
+        with:
+          # https://github.com/DeterminateSystems/nix-installer/tree/lazy-trees
+          source-revision: "lazy-trees"
+      - name: Ensure that Nix is installed via alternative source-branch
+        run: nix --version
+
+      - name: Install with alternative source-tag
+        uses: ./.
+        with:
+          # https://github.com/DeterminateSystems/nix-installer/tree/v0.14.0
+          source-tag: "v0.14.0"
+      - name: Ensure that Nix is installed via alternative source-tag
         run: nix --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
       - name: Compare Nix version with expected version
         run: |
           NIX_VERSION_OUTPUT=$(nix --version)
-          NIX_VERSION=$(echo "${NIX_VERSION}" | awk '{print $NF}')
+          NIX_VERSION=$(echo "${NIX_VERSION_OUTPUT}" | awk '{print $NF}')
           EXPECTED_OUTPUT="nix (Nix) ${{ matrix.versions.nix }}"
           if [ "${NIX_VERSION_OUTPUT}" != "${EXPECTED_OUTPUT}" ]; then
             echo "Nix version ${NIX_VERSION} didn't match expected version ${{ matrix.versions.nix }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,9 +215,15 @@ jobs:
   install-with-non-default-inputs:
     name: Install Nix using non-default Action inputs
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        version:
+          - "0.17.0"
+          - "0.18.0"
+          - "0.19.0"
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
         with:
-          source-url: https://github.com/DeterminateSystems/nix-installer/releases/download/v0.19.0/nix-installer-x86_64-linux
+          source-url: https://github.com/DeterminateSystems/nix-installer/releases/download/v${{ matrix.version }}/nix-installer-x86_64-linux
       - run: nix --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,8 @@ jobs:
     name: Install Nix using non-default source-url inputs
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4
+
       - name: Install with alternative source-url
         uses: ./
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,5 +219,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
         with:
-          source-url: https://install.determinate.systems/nix-installer/stable/X64-Linux
+          source-url: https://github.com/DeterminateSystems/nix-installer/releases/download/v0.19.0/nix-installer-x86_64-linux
       - run: nix --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,8 +218,8 @@ jobs:
     strategy:
       matrix:
         versions:
-          - { nix-installer: "0.12.0", nix: "2.20.0" }
-          - { nix-installer: "0.14.0", nix: "2.20.0" }
+          - { nix-installer: "0.12.0", nix: "2.18.0" }
+          - { nix-installer: "0.14.0", nix: "2.18.1" }
           - { nix-installer: "0.18.0", nix: "2.20.0" }
     steps:
       - uses: actions/checkout@v4
@@ -234,4 +234,6 @@ jobs:
           if [ "${NIX_VERSION_OUTPUT}" != "${EXPECTED_OUTPUT}" ]; then
             echo "Nix version ${NIX_VERSION} didn't match expected version ${{ matrix.versions.nix }}"
             exit 1
+          else
+            echo "Success! Nix version ${NIX_VERSION} installed as expected"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,9 +226,10 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           source-url: https://github.com/DeterminateSystems/nix-installer/releases/download/v${{ matrix.versions.nix-installer }}/nix-installer-x86_64-linux
-      - run: |
+      - name: Compare Nix version with expected version
+        run: |
           NIX_VERSION_OUTPUT=$(nix --version)
-          NIX_VERSION=$(echo "{NIX_VERSION}" | awk '{print $NF}')
+          NIX_VERSION=$(echo "${NIX_VERSION}" | awk '{print $NF}')
           EXPECTED_OUTPUT="nix (Nix) ${{ matrix.versions.nix }}"
           if [ "${NIX_VERSION_OUTPUT}" != "${EXPECTED_OUTPUT}" ]; then
             echo "Nix version ${NIX_VERSION} didn't match expected version ${{ matrix.versions.nix }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,3 +211,13 @@ jobs:
         with:
           duration: 5m
           authorized-users: grahamc
+
+  install-with-non-default-inputs:
+    name: Install Nix using non-default Action inputs
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          source-url: https://install.determinate.systems/nix-installer/stable/X64-Linux
+      - run: nix --version

--- a/action.yml
+++ b/action.yml
@@ -92,7 +92,7 @@ inputs:
     description: The tag of `nix-installer` to use (conflicts with `source-revision`, `source-branch`, `source-pr`)
     required: false
   source-url:
-    description: A URL pointing to a `nix-installer.sh` script
+    description: A URL pointing to a `nix-installer` executable
     required: false
   nix-package-url:
     description: The Nix package URL


### PR DESCRIPTION
Fixes #84.

Updates the misleading `action.yml` description and also adds a basic GHA workflow for a handful of non-default `source-*` inputs.