### PR TITLE
tests: make megajob block on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,13 @@ jobs:
       - install-nix-linux
       - install-nix-macos
       - install-with-non-default-source-inputs
+    # NOTE(cole-h): GitHub treats "skipped" as "OK" for the purposes of required checks on branch
+    # protection, so we take advantage of this fact and fail if any of the dependent actions failed,
+    # or "skip" (which is a success for GHA's purposes) if none of them did.
+    if: failure()
     steps:
-      - run: true
+      - name: Dependent checks failed
+        run: exit 1
 
   check-dist-up-to-date:
     name: Check the dist/ folder is up to date


### PR DESCRIPTION
GitHub Actions considers a "skipped" job successful for the purposes of required jobs for branch protections. We take advantage of this by failing if any dependent actions failed, or "skip" if they all succeeded.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation
behind it
--->

##### Checklist

- [ ] Tested changes against a test repository
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] (If this PR is for a release) Updated README to point to the new tag (leave unchecked if not applicable)
