### PR TITLE
Check whether the current user has access to KVM before attempting to add udev rule

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -85207,11 +85207,22 @@ ${stderrBuffer}`
       return false;
     }
   }
+  async canAccessKvm() {
+    try {
+      await (0,promises_namespaceObject.access)("/dev/kvm", external_node_fs_namespaceObject.constants.R_OK | external_node_fs_namespaceObject.constants.W_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
   async setupKvm() {
     this.recordEvent(EVENT_SETUP_KVM);
     const currentUser = (0,external_node_os_.userInfo)();
     const isRoot = currentUser.uid === 0;
     const maybeSudo = isRoot ? "" : "sudo";
+    if (await this.canAccessKvm()) {
+      return true;
+    }
     const kvmRules = "/etc/udev/rules.d/99-determinate-nix-installer-kvm.rules";
     try {
       const writeFileExitCode = await exec.exec(

--- a/src/index.ts
+++ b/src/index.ts
@@ -935,12 +935,27 @@ class NixInstallerAction extends DetSysAction {
     }
   }
 
+  private async canAccessKvm(): Promise<boolean> {
+    try {
+      await access("/dev/kvm", fs.constants.R_OK | fs.constants.W_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   private async setupKvm(): Promise<boolean> {
     this.recordEvent(EVENT_SETUP_KVM);
     const currentUser = userInfo();
     const isRoot = currentUser.uid === 0;
     const maybeSudo = isRoot ? "" : "sudo";
 
+    // First check to see whether the current user can open the KVM device node
+    if (await this.canAccessKvm()) {
+      return true;
+    }
+
+    // The current user can't access KVM, so try adding a udev rule to allow access to all users and groups
     const kvmRules = "/etc/udev/rules.d/99-determinate-nix-installer-kvm.rules";
     try {
       const writeFileExitCode = await actionsExec.exec(


### PR DESCRIPTION
##### Description

I've recently started using this action with a runner using [act](https://github.com/nektos/act), which uses docker containers to provide the standard actions environments (such as `ubuntu-latest`). I'd like to use this action to install nix with kvm enabled, but currently the KVM setup fails due to udev not being installed in the docker container.

KVM is already fully functional inside the container (I've passed `/dev/kvm` to the docker container and added the runner user to the `kvm` group), so installing udev and modifying rules is unnecessary.

This PR checks whether KVM is available to the current user, and if it is then it skips setting up udev rules.

##### Checklist

- [x] Tested changes against a test repository
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] (If this PR is for a release) Updated README to point to the new tag (leave unchecked if not applicable)
