### PR TITLE
Annotate hash mismatches when Determinate features are enabled

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -88959,6 +88959,7 @@ var NixInstallerAction = class extends DetSysAction {
     await this.scienceDebugFly();
     await this.detectAndForceDockerShim();
     await this.install();
+    await this.slurpEventLog();
   }
   async post() {
     await this.cleanupDockerShim();

--- a/dist/index.js
+++ b/dist/index.js
@@ -89801,13 +89801,16 @@ ${stderrBuffer}`
     const logfile = this.getTemporaryName();
     core.saveState(STATE_EVENT_LOG, logfile);
     const output = await (0,promises_namespaceObject.open)(logfile, "a");
+    const stderr = await (0,promises_namespaceObject.open)(`${logfile}.stderr`, "a");
+    core.debug(`Event log: ${logfile}`);
     const opts = {
-      stdio: ["ignore", output.fd, "ignore"],
+      stdio: ["ignore", output.fd, stderr.fd],
       detached: true
     };
     const daemon = (0,external_node_child_process_namespaceObject.spawn)(
       "curl",
       [
+        "-v",
         "--unix-socket",
         "/nix/var/determinate/determinate-nixd.socket",
         "http://localhost/events"

--- a/dist/index.js
+++ b/dist/index.js
@@ -89810,7 +89810,7 @@ ${stderrBuffer}`
     const daemon = (0,external_node_child_process_namespaceObject.spawn)(
       "curl",
       [
-        "-v",
+        "--no-buffer",
         "--unix-socket",
         "/nix/var/determinate/determinate-nixd.socket",
         "http://localhost/events"

--- a/dist/index.js
+++ b/dist/index.js
@@ -89857,7 +89857,7 @@ ${stderrBuffer}`
             }
             const column = (match.index ?? 0) + 1;
             core.error(`This derivation's hash is \`${event.good}\``, {
-              title: "Determinate Nix detected an incorrect dependency hash.",
+              title: "Determinate Nix detected an incorrect dependency hash",
               file,
               startLine: lineNumber,
               startColumn: column

--- a/dist/index.js
+++ b/dist/index.js
@@ -89802,11 +89802,11 @@ ${stderrBuffer}`
     }
     const logfile = this.getTemporaryName();
     core.saveState(STATE_EVENT_LOG, logfile);
-    const output = await (0,promises_namespaceObject.open)(logfile, "a");
+    const stdout = await (0,promises_namespaceObject.open)(logfile, "a");
     const stderr = await (0,promises_namespaceObject.open)(`${logfile}.stderr`, "a");
     core.debug(`Event log: ${logfile}`);
     const opts = {
-      stdio: ["ignore", output.fd, stderr.fd],
+      stdio: ["ignore", stdout.fd, stderr.fd],
       detached: true
     };
     const daemon = (0,external_node_child_process_namespaceObject.spawn)(
@@ -89821,6 +89821,17 @@ ${stderrBuffer}`
     );
     core.saveState(STATE_EVENT_PID, daemon.pid);
     daemon.unref();
+    await Promise.resolve();
+    try {
+      await stdout.close();
+    } catch (error2) {
+      core.info(`Could not close curl's stdout: ${error2}`);
+    }
+    try {
+      await stderr.close();
+    } catch (error2) {
+      core.info(`Could not close curl's stderr: ${error2}`);
+    }
   }
   async slurpEventLog() {
     if (!this.determinate) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,6 +133,7 @@ class NixInstallerAction extends DetSysAction {
     await this.cleanupDockerShim();
     await this.reportOverall();
     await this.slurpEventLog();
+    await this.cleanupLogger();
   }
 
   private get isMacOS(): boolean {
@@ -1192,6 +1193,17 @@ class NixInstallerAction extends DetSysAction {
     } catch (error) {
       // Don't hard fail the action if something exploded; this feature is only a nice-to-have
       actionsCore.warning(`Could not consume hash mismatch logs: ${error}`);
+    }
+  }
+
+  async cleanupLogger(): Promise<void> {
+    const rawPid = actionsCore.getState(STATE_EVENT_PID);
+    const pid = Number(rawPid);
+
+    try {
+      process.kill(pid);
+    } catch (error) {
+      actionsCore.warning(`Could not kill pid ${rawPid}: ${error}`);
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1181,8 +1181,8 @@ class NixInstallerAction extends DetSysAction {
             // Allegedly, match.index is optional, so default to 0
             const column = (match.index ?? 0) + 1;
 
-            actionsCore.error(`This derivation's hash is ${event.good}`, {
-              title: "Outdated hash",
+            actionsCore.error(`This derivation's hash is \`${event.good}\``, {
+              title: "Determinate Nix detected an incorrect dependency hash.",
               file,
               startLine: lineNumber,
               startColumn: column,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1203,7 +1203,7 @@ class NixInstallerAction extends DetSysAction {
     try {
       process.kill(pid);
     } catch (error) {
-      actionsCore.warning(`Could not kill pid ${rawPid}: ${error}`);
+      actionsCore.info(`Could not kill pid ${rawPid}: ${error}`);
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1225,7 +1225,7 @@ async function readMismatchEvents(logPath: string): Promise<MismatchEvent[]> {
       // Construct a regular expression to search for any of the hash patterns
       // (do it here to avoid creating RegExp objects in a loop below)
       const search = new RegExp(
-        source.bad.map((s) => s.replace(/[+]/, (ch) => `\\${ch}`)).join("|"),
+        source.bad.map((s) => s.replace(/[+]/g, (ch) => `\\${ch}`)).join("|"),
       );
 
       return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1119,9 +1119,12 @@ class NixInstallerAction extends DetSysAction {
     const logfile = this.getTemporaryName();
     actionsCore.saveState(STATE_EVENT_LOG, logfile);
     const output = await open(logfile, "a");
+    const stderr = await open(`${logfile}.stderr`, "a");
+
+    actionsCore.debug(`Event log: ${logfile}`);
 
     const opts: SpawnOptions = {
-      stdio: ["ignore", output.fd, "ignore"],
+      stdio: ["ignore", output.fd, stderr.fd],
       detached: true,
     };
 
@@ -1129,6 +1132,7 @@ class NixInstallerAction extends DetSysAction {
     const daemon = spawn(
       "curl",
       [
+        "-v",
         "--unix-socket",
         "/nix/var/determinate/determinate-nixd.socket",
         "http://localhost/events",

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,7 @@ class NixInstallerAction extends DetSysAction {
     await this.scienceDebugFly();
     await this.detectAndForceDockerShim();
     await this.install();
+    await this.slurpEventLog();
   }
 
   async post(): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1196,7 +1196,7 @@ class NixInstallerAction extends DetSysAction {
             const column = (match.index ?? 0) + 1;
 
             actionsCore.error(`This derivation's hash is \`${event.good}\``, {
-              title: "Determinate Nix detected an incorrect dependency hash.",
+              title: "Determinate Nix detected an incorrect dependency hash",
               file,
               startLine: lineNumber,
               startColumn: column,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1132,7 +1132,7 @@ class NixInstallerAction extends DetSysAction {
     const daemon = spawn(
       "curl",
       [
-        "-v",
+        "--no-buffer",
         "--unix-socket",
         "/nix/var/determinate/determinate-nixd.socket",
         "http://localhost/events",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1265,9 +1265,13 @@ async function getFileListing(): Promise<readonly string[]> {
     const chunks: Buffer[] = [];
     let length = 0;
 
-    const child = spawn("git", ["ls-files", "*.nix", "*.json", "*.toml"], {
-      stdio: ["ignore", "pipe", "inherit"],
-    });
+    const child = spawn(
+      "git",
+      ["ls-files", "-z", "*.nix", "*.json", "*.toml"],
+      {
+        stdio: ["ignore", "pipe", "inherit"],
+      },
+    );
 
     child.stdout.on("data", (chunk: Buffer) => {
       chunks.push(chunk);
@@ -1275,7 +1279,11 @@ async function getFileListing(): Promise<readonly string[]> {
     });
 
     child.stdout.on("end", () => {
-      const lines = Buffer.concat(chunks, length).toString("utf-8").split(/\n/);
+      const lines = Buffer.concat(chunks, length)
+        .toString("utf-8")
+        .replace(/\0$/, "")
+        .split(/\0/);
+
       resolve(lines);
     });
 


### PR DESCRIPTION
##### Description

When Determinate features are enabled, this PR adds GitHub Actions annotations to point users directly to hash mismatches in their source files. 

##### Checklist

- [x] Tested changes against a test repository
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] (If this PR is for a release) Updated README to point to the new tag (leave unchecked if not applicable)
