### PR TITLE
Don't blow the limits of summaries, by not printing logs if it blows the limit

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -88866,16 +88866,14 @@ function mermaidify(allEvents, pruneLevel) {
 // src/failuresummary.ts
 
 
+var defaultMaxSummaryLength = 995e3;
 function getBuildFailures(events) {
   return events.filter((event) => {
     return event.c === "BuildFailureResponseEventV1";
   });
 }
-async function summarizeFailures(events, getLog = getLogFromNix, maxLength) {
+async function summarizeFailures(events, getLog = getLogFromNix, maxLength = defaultMaxSummaryLength) {
   const failures = getBuildFailures(events);
-  if (maxLength === void 0) {
-    maxLength = 995e3;
-  }
   if (failures.length === 0) {
     return void 0;
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -88931,11 +88931,9 @@ async function summarizeFailures(events, getLog = getLogFromNix, maxLength) {
   }
   if (skippedChunks.length > 0) {
     markdownLines.push(
-      ...[
-        "> [!NOTE]",
-        `> The following ${skippedChunks.length === 1 ? "failure has" : "failures have"} been ommitted due to GitHub Actions summary length limitations.`,
-        "> The full logs are available in the post-run phase of the Nix Installer Action."
-      ]
+      "> [!NOTE]",
+      `> The following ${skippedChunks.length === 1 ? "failure has" : "failures have"} been ommitted due to GitHub Actions summary length limitations.`,
+      "> The full logs are available in the post-run phase of the Nix Installer Action."
     );
     logLines.push(
       "The following build logs are NOT available in the Markdown summary:"

--- a/src/failuresummary.test.ts
+++ b/src/failuresummary.test.ts
@@ -192,3 +192,64 @@ Note: Look at the actions summary for a markdown rendering.
     /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-3.drv
 ::endgroup::`);
 });
+
+test("Omit some logs if there are too many", async () => {
+  const events = [
+    {
+      v: "1",
+      c: "BuildFailureResponseEventV1",
+      drv: `/nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv`,
+      timing: {
+        startTime: new Date(1 * 1000),
+        durationSeconds: 1,
+      },
+    },
+    {
+      v: "1",
+      c: "BuiltPathResponseEventV1",
+      drv: `/nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-2.drv`,
+      timing: {
+        startTime: new Date(2 * 1000),
+        durationSeconds: 2,
+      },
+    },
+    {
+      v: "1",
+      c: "BuildFailureResponseEventV1",
+      drv: `/nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-3.drv`,
+      timing: {
+        startTime: new Date(3 * 1000),
+        durationSeconds: 3,
+      },
+    },
+  ];
+
+  const logMaker = async (drv: string): Promise<string | undefined> => {
+    return `${drv}\n`.repeat(5).trimEnd();
+  };
+
+  const summary: FailureSummary = (await summarizeFailures(
+    events,
+    logMaker,
+    500,
+  ))!;
+
+  expect(summary.markdownLines.join("\n"))
+    .toStrictEqual(`### Build error review :boom:
+> [!NOTE]
+> 2 builds failed
+<details><summary>Failure log: <code>/nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-<strong>dep-1</strong>.drv</code></summary>
+
+    /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv
+    /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv
+    /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv
+    /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv
+    /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv
+
+</details>
+
+> [!NOTE]
+> The following failure has been ommitted due to GitHub Actions summary length limitations.
+> The full logs are available in the post-run phase of the Nix Installer Action.
+> * \`/nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-3.drv\``);
+});

--- a/src/failuresummary.test.ts
+++ b/src/failuresummary.test.ts
@@ -152,7 +152,7 @@ test("Summarize Failures", async () => {
 
   expect(summary.logLines.join("\n"))
     .toStrictEqual(`\u001b[38;2;255;0;0mBuild logs from 2 failures
-Note: Look at the actions summary for a markdown rendering.
+The following build logs are also available in the Markdown summary:
 ::group::Failed build: /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv
     /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv
     /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv
@@ -252,4 +252,23 @@ test("Omit some logs if there are too many", async () => {
 > The following failure has been ommitted due to GitHub Actions summary length limitations.
 > The full logs are available in the post-run phase of the Nix Installer Action.
 > * \`/nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-3.drv\``);
+
+  expect(summary.logLines.join("\n"))
+    .toStrictEqual(`\u001b[38;2;255;0;0mBuild logs from 2 failures
+The following build logs are also available in the Markdown summary:
+::group::Failed build: /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv
+    /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv
+    /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv
+    /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv
+    /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv
+    /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv
+::endgroup::
+The following build logs are NOT available in the Markdown summary:
+::group::Failed build: /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-3.drv
+    /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-3.drv
+    /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-3.drv
+    /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-3.drv
+    /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-3.drv
+    /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-3.drv
+::endgroup::`);
 });

--- a/src/failuresummary.ts
+++ b/src/failuresummary.ts
@@ -99,11 +99,9 @@ export async function summarizeFailures(
 
   if (skippedChunks.length > 0) {
     markdownLines.push(
-      ...[
-        "> [!NOTE]",
-        `> The following ${skippedChunks.length === 1 ? "failure has" : "failures have"} been ommitted due to GitHub Actions summary length limitations.`,
-        "> The full logs are available in the post-run phase of the Nix Installer Action.",
-      ],
+      "> [!NOTE]",
+      `> The following ${skippedChunks.length === 1 ? "failure has" : "failures have"} been ommitted due to GitHub Actions summary length limitations.`,
+      "> The full logs are available in the post-run phase of the Nix Installer Action.",
     );
 
     logLines.push(


### PR DESCRIPTION
##### Description

In https://github.com/DeterminateSystems/nixos-vault-service/actions/runs/14625223942 we got an error:
> $GITHUB_STEP_SUMMARY upload aborted, supports content up to a size of 1024k, got 1063k. For more information see: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-markdown-summary

This PR clamps the length to a displayable limit, and shows the user how to see the logs anyway.
 
It now looks like this if the log is too large:

> ### Build error review :boom:
> > [!NOTE]
> > 2 builds failed
> <details><summary>Failure log: <code>/nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-<strong>dep-1</strong>.drv</code></summary>
> 
>     /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv
>     /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv
>     /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv
>     /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv
>     /nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-1.drv
> 
> </details>
> 
> > [!NOTE]
> > The following failure has been ommitted due to GitHub Actions summary length limitations.
> > The full logs are available in the post-run phase of the Nix Installer Action.
> > * `/nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-3.drv`

---

##### Checklist

- [ ] Tested changes against a test repository
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] (If this PR is for a release) Updated README to point to the new tag (leave unchecked if not applicable)
