### PR TITLE
Correctly suppress empty summaries

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -93064,7 +93064,7 @@ function makeMermaidReport(events) {
     pruneLevel += 1;
     mermaid = mermaidify(events, pruneLevel) ?? "";
   } while (mermaid.length > maxLength);
-  if (mermaid === void 0) {
+  if (!mermaid) {
     return void 0;
   }
   const lines = [

--- a/src/mermaid.ts
+++ b/src/mermaid.ts
@@ -12,7 +12,7 @@ export function makeMermaidReport(events: DEvent[]): string | undefined {
     mermaid = mermaidify(events, pruneLevel) ?? "";
   } while (mermaid.length > maxLength);
 
-  if (mermaid === undefined) {
+  if (!mermaid) {
     return undefined;
   }
 


### PR DESCRIPTION
For some reason, TypeScript didn't catch this: `string` and `undefined` shouldn't be comparable since they have no overlapping types.

I've chosen to just use the short-cut falsy check here to avoid future complications.