### PR TITLE
Fix an obscure error case where if the only log fails, the rendering is wack

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -95334,7 +95334,7 @@ function makeMermaidReport(events) {
   } else if (pruneLevel > 0) {
     lines.push("> [!NOTE]");
     lines.push(
-      `> \`/nix/store/[hash]\`, the \`.drv\` suffix, and builds that took less than ${collapseSeconds(pruneLevel)} have been removed to make the graph small enough to render.`
+      `> \`/nix/store/[hash]\`, the \`.drv\` suffix, and builds that took less than ${formatDuration(pruneLevel)} have been removed to make the graph small enough to render.`
     );
   }
   lines.push("");
@@ -95367,13 +95367,13 @@ function mermaidify(allEvents, pruneLevel) {
     const tag = event.c === "BuildFailureResponseEventV1" ? "crit" : "d";
     const relativeStartTime = (event.timing.startTime.getTime() - zeroMoment) / 1e3;
     lines.push(
-      `${label} (${collapseSeconds(duration)}):${tag}, ${relativeStartTime}, ${duration}s`
+      `${label} (${formatDuration(duration)}):${tag}, ${relativeStartTime}, ${duration}s`
     );
   }
   lines.push("```");
   return lines.join("\n");
 }
-function collapseSeconds(duration) {
+function formatDuration(duration) {
   const durSeconds = duration % 60;
   const durMinutes = (duration - durSeconds) / 60;
   return `${durMinutes > 0 ? `${durMinutes}m` : ""}${durSeconds}s`;
@@ -95447,7 +95447,7 @@ async function summarizeFailures(events, getLog = getLogFromNix, maxLength = def
     markdownLines.push(
       "",
       "> [!NOTE]",
-      `> The following ${skippedChunks.length === 1 ? "failure has" : "failures have"} been omitted due to GitHub Actions summary length limitations.`,
+      `> The following ${skippedChunks.length === 1 ? "failure has" : "failures have"} been omitted due to GitHub Actions' summary length limitations.`,
       "> The full logs are available in the post-run phase of the Nix Installer Action."
     );
     logLines.push(

--- a/dist/index.js
+++ b/dist/index.js
@@ -95334,7 +95334,7 @@ function makeMermaidReport(events) {
   } else if (pruneLevel > 0) {
     lines.push("> [!NOTE]");
     lines.push(
-      `> \`/nix/store/[hash]\`, the \`.drv\` suffix, and builds that took less than ${pruneLevel}s have been removed to make the graph small enough to render.`
+      `> \`/nix/store/[hash]\`, the \`.drv\` suffix, and builds that took less than ${collapseSeconds(pruneLevel)} have been removed to make the graph small enough to render.`
     );
   }
   lines.push("");
@@ -95367,11 +95367,16 @@ function mermaidify(allEvents, pruneLevel) {
     const tag = event.c === "BuildFailureResponseEventV1" ? "crit" : "d";
     const relativeStartTime = (event.timing.startTime.getTime() - zeroMoment) / 1e3;
     lines.push(
-      `${label} (${duration}s):${tag}, ${relativeStartTime}, ${duration}s`
+      `${label} (${collapseSeconds(duration)}):${tag}, ${relativeStartTime}, ${duration}s`
     );
   }
   lines.push("```");
   return lines.join("\n");
+}
+function collapseSeconds(duration) {
+  const durSeconds = duration % 60;
+  const durMinutes = (duration - durSeconds) / 60;
+  return `${durMinutes > 0 ? `${durMinutes}m` : ""}${durSeconds}s`;
 }
 
 // src/failuresummary.ts

--- a/dist/index.js
+++ b/dist/index.js
@@ -95440,6 +95440,7 @@ async function summarizeFailures(events, getLog = getLogFromNix, maxLength = def
   }
   if (skippedChunks.length > 0) {
     markdownLines.push(
+      "",
       "> [!NOTE]",
       `> The following ${skippedChunks.length === 1 ? "failure has" : "failures have"} been omitted due to GitHub Actions summary length limitations.`,
       "> The full logs are available in the post-run phase of the Nix Installer Action."

--- a/dist/index.js
+++ b/dist/index.js
@@ -95441,7 +95441,7 @@ async function summarizeFailures(events, getLog = getLogFromNix, maxLength = def
   if (skippedChunks.length > 0) {
     markdownLines.push(
       "> [!NOTE]",
-      `> The following ${skippedChunks.length === 1 ? "failure has" : "failures have"} been ommitted due to GitHub Actions summary length limitations.`,
+      `> The following ${skippedChunks.length === 1 ? "failure has" : "failures have"} been omitted due to GitHub Actions summary length limitations.`,
       "> The full logs are available in the post-run phase of the Nix Installer Action."
     );
     logLines.push(

--- a/src/failuresummary.test.ts
+++ b/src/failuresummary.test.ts
@@ -249,7 +249,7 @@ test("Omit some logs if there are too many", async () => {
 </details>
 
 > [!NOTE]
-> The following failure has been ommitted due to GitHub Actions summary length limitations.
+> The following failure has been omitted due to GitHub Actions summary length limitations.
 > The full logs are available in the post-run phase of the Nix Installer Action.
 > * \`/nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-3.drv\``);
 

--- a/src/failuresummary.test.ts
+++ b/src/failuresummary.test.ts
@@ -248,6 +248,7 @@ test("Omit some logs if there are too many", async () => {
 
 </details>
 
+
 > [!NOTE]
 > The following failure has been omitted due to GitHub Actions summary length limitations.
 > The full logs are available in the post-run phase of the Nix Installer Action.

--- a/src/failuresummary.test.ts
+++ b/src/failuresummary.test.ts
@@ -250,7 +250,7 @@ test("Omit some logs if there are too many", async () => {
 
 
 > [!NOTE]
-> The following failure has been omitted due to GitHub Actions summary length limitations.
+> The following failure has been omitted due to GitHub Actions' summary length limitations.
 > The full logs are available in the post-run phase of the Nix Installer Action.
 > * \`/nix/store/rz9hrpay90sjrid5hx3x8v606ji679xa-dep-3.drv\``);
 

--- a/src/failuresummary.ts
+++ b/src/failuresummary.ts
@@ -97,6 +97,7 @@ export async function summarizeFailures(
 
   if (skippedChunks.length > 0) {
     markdownLines.push(
+      "",
       "> [!NOTE]",
       `> The following ${skippedChunks.length === 1 ? "failure has" : "failures have"} been omitted due to GitHub Actions summary length limitations.`,
       "> The full logs are available in the post-run phase of the Nix Installer Action.",

--- a/src/failuresummary.ts
+++ b/src/failuresummary.ts
@@ -99,7 +99,7 @@ export async function summarizeFailures(
     markdownLines.push(
       "",
       "> [!NOTE]",
-      `> The following ${skippedChunks.length === 1 ? "failure has" : "failures have"} been omitted due to GitHub Actions summary length limitations.`,
+      `> The following ${skippedChunks.length === 1 ? "failure has" : "failures have"} been omitted due to GitHub Actions' summary length limitations.`,
       "> The full logs are available in the post-run phase of the Nix Installer Action.",
     );
 

--- a/src/failuresummary.ts
+++ b/src/failuresummary.ts
@@ -98,7 +98,7 @@ export async function summarizeFailures(
   if (skippedChunks.length > 0) {
     markdownLines.push(
       "> [!NOTE]",
-      `> The following ${skippedChunks.length === 1 ? "failure has" : "failures have"} been ommitted due to GitHub Actions summary length limitations.`,
+      `> The following ${skippedChunks.length === 1 ? "failure has" : "failures have"} been omitted due to GitHub Actions summary length limitations.`,
       "> The full logs are available in the post-run phase of the Nix Installer Action.",
     );
 

--- a/src/mermaid.ts
+++ b/src/mermaid.ts
@@ -31,7 +31,7 @@ export function makeMermaidReport(events: DEvent[]): string | undefined {
   } else if (pruneLevel > 0) {
     lines.push("> [!NOTE]");
     lines.push(
-      `> \`/nix/store/[hash]\`, the \`.drv\` suffix, and builds that took less than ${collapseSeconds(pruneLevel)} have been removed to make the graph small enough to render.`,
+      `> \`/nix/store/[hash]\`, the \`.drv\` suffix, and builds that took less than ${formatDuration(pruneLevel)} have been removed to make the graph small enough to render.`,
     );
   }
 
@@ -81,7 +81,7 @@ export function mermaidify(
       (event.timing.startTime.getTime() - zeroMoment) / 1000;
 
     lines.push(
-      `${label} (${collapseSeconds(duration)}):${tag}, ${relativeStartTime}, ${duration}s`,
+      `${label} (${formatDuration(duration)}):${tag}, ${relativeStartTime}, ${duration}s`,
     );
   }
   lines.push("```");
@@ -89,7 +89,7 @@ export function mermaidify(
   return lines.join("\n");
 }
 
-function collapseSeconds(duration: number): string {
+function formatDuration(duration: number): string {
   const durSeconds = duration % 60;
   const durMinutes = (duration - durSeconds) / 60;
   return `${durMinutes > 0 ? `${durMinutes}m` : ""}${durSeconds}s`;

--- a/src/mermaid.ts
+++ b/src/mermaid.ts
@@ -31,7 +31,7 @@ export function makeMermaidReport(events: DEvent[]): string | undefined {
   } else if (pruneLevel > 0) {
     lines.push("> [!NOTE]");
     lines.push(
-      `> \`/nix/store/[hash]\`, the \`.drv\` suffix, and builds that took less than ${pruneLevel}s have been removed to make the graph small enough to render.`,
+      `> \`/nix/store/[hash]\`, the \`.drv\` suffix, and builds that took less than ${collapseSeconds(pruneLevel)} have been removed to make the graph small enough to render.`,
     );
   }
 
@@ -81,10 +81,16 @@ export function mermaidify(
       (event.timing.startTime.getTime() - zeroMoment) / 1000;
 
     lines.push(
-      `${label} (${duration}s):${tag}, ${relativeStartTime}, ${duration}s`,
+      `${label} (${collapseSeconds(duration)}):${tag}, ${relativeStartTime}, ${duration}s`,
     );
   }
   lines.push("```");
 
   return lines.join("\n");
+}
+
+function collapseSeconds(duration: number): string {
+  const durSeconds = duration % 60;
+  const durMinutes = (duration - durSeconds) / 60;
+  return `${durMinutes > 0 ? `${durMinutes}m` : ""}${durSeconds}s`;
 }


### PR DESCRIPTION
##### Description


https://github.com/DeterminateSystems/docs.determinate.systems/actions/runs/14893979984/attempts/1#summary-41832596554

first, long jobs are showing thousands of seconds in the graph,

and there is a double NOTE:

> [!NOTE]
> 1 build failed
> [!NOTE]
> The following failure has been ommitted due to GitHub Actions summary length limitations.
> The full logs are available in the post-run phase of the Nix Installer Action.
 
/nix/store/m7gxzgk460q28z52xh211r0gwvz4ak24-nodejs-20.19.0.drv


##### Checklist

- [ ] Tested changes against a test repository
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] (If this PR is for a release) Updated README to point to the new tag (leave unchecked if not applicable)
