### PR TITLE
Record events if authentication is skipped

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -100504,13 +100504,13 @@ var NixInstallerAction = class extends DetSysAction {
       if (pr && base !== head) {
         this.recordEvent(EVENT_LOGIN_FAILURE, { reason: "fork" });
         core.info(
-          `Not logging in to FlakeHub: GitHub Actions does not allow OIDC authentication from forked repositories ("${head}" is not the same repository as "${base}").`
+          `FlakeHub is disabled because this is a fork. GitHub Actions does not allow OIDC authentication from forked repositories ("${head}" is not from the same repository as "${base}").`
         );
         return;
       }
       this.recordEvent(EVENT_LOGIN_FAILURE, { reason: "not-configured" });
       core.info(
-        `Not logging in to FlakeHub: GitHub Actions has not provided OIDC token endpoints; please make sure that \`id-token: write\` and \`contents: read\` are set for this step's (or job's) permissions.`
+        "FlakeHub is disabled because the workflow is misconfigured. Please make sure that `id-token: write` and `contents: read` are set for this step's (or job's) permissions so that GitHub Actions provides OIDC token endpoints."
       );
       core.info(
         `For more information, see https://docs.determinate.systems/guides/github-actions/#nix-installer-action`

--- a/src/index.ts
+++ b/src/index.ts
@@ -728,7 +728,7 @@ class NixInstallerAction extends DetSysAction {
       if (pr && base !== head) {
         this.recordEvent(EVENT_LOGIN_FAILURE, { reason: "fork" });
         actionsCore.info(
-          `Not logging in to FlakeHub: GitHub Actions does not allow OIDC authentication from forked repositories ("${head}" is not the same repository as "${base}").`,
+          `FlakeHub is disabled because this is a fork. GitHub Actions does not allow OIDC authentication from forked repositories ("${head}" is not from the same repository as "${base}").`,
         );
         return;
       }
@@ -736,7 +736,7 @@ class NixInstallerAction extends DetSysAction {
       this.recordEvent(EVENT_LOGIN_FAILURE, { reason: "not-configured" });
 
       actionsCore.info(
-        `Not logging in to FlakeHub: GitHub Actions has not provided OIDC token endpoints; please make sure that \`id-token: write\` and \`contents: read\` are set for this step's (or job's) permissions.`,
+        "FlakeHub is disabled because the workflow is misconfigured. Please make sure that `id-token: write` and `contents: read` are set for this step's (or job's) permissions so that GitHub Actions provides OIDC token endpoints.",
       );
       actionsCore.info(
         `For more information, see https://docs.determinate.systems/guides/github-actions/#nix-installer-action`,


### PR DESCRIPTION
##### Description

This PR adds `auth-skip` events of two types in order for us to be able to see possible repository issues. This should cut down on the misdiagnosis of authentication failures.

##### Checklist

- [ ] Tested changes against a test repository
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] (If this PR is for a release) Updated README to point to the new tag (leave unchecked if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - None.

- Chores
  - Clarified user-facing messages when FlakeHub is disabled: explains forked PRs versus misconfigured repositories and prompts to ensure ID token and contents permissions are set.
  - Improved telemetry for login failures to distinguish fork vs not-configured vs failed attempts (no change to user workflows).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->