### PR TITLE
Treat FlakeHub logins as a funnel

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -99926,8 +99926,10 @@ var EVENT_INSTALL_NIX_START = "install_nix_start";
 var EVENT_INSTALL_NIX_SUCCESS = "install_nix_start";
 var EVENT_SETUP_KVM = "setup_kvm";
 var EVENT_UNINSTALL_NIX = "uninstall";
-var EVENT_LOGIN_TO_FLAKEHUB = "login_to_flakehub";
+var EVENT_LOGIN_START = "flakehub-login:start";
 var EVENT_LOGIN_FAILURE = "flakehub-login:failure";
+var EVENT_LOGIN_SUCCESS = "flakehub-login:success";
+var EVENT_LOGIN_END = "flakehub-login:end";
 var EVENT_CONCLUDE_JOB = "conclude_job";
 var EVENT_FOD_ANNOTATE = "fod_annotate";
 var EVENT_NO_SYSTEMD_SHIM_FAILED = "no-systemd-shim-failed";
@@ -100496,6 +100498,7 @@ var NixInstallerAction = class extends DetSysAction {
     }
   }
   async flakehubLogin() {
+    this.recordEvent(EVENT_LOGIN_START);
     const canLogin = process.env["ACTIONS_ID_TOKEN_REQUEST_URL"] && process.env["ACTIONS_ID_TOKEN_REQUEST_TOKEN"];
     if (!canLogin) {
       const pr = github.context.payload.pull_request;
@@ -100503,12 +100506,14 @@ var NixInstallerAction = class extends DetSysAction {
       const head = pr?.head?.repo?.full_name;
       if (pr && base !== head) {
         this.recordEvent(EVENT_LOGIN_FAILURE, { reason: "fork" });
+        this.recordEvent(EVENT_LOGIN_END);
         core.info(
           `FlakeHub is disabled because this is a fork. GitHub Actions does not allow OIDC authentication from forked repositories ("${head}" is not from the same repository as "${base}").`
         );
         return;
       }
       this.recordEvent(EVENT_LOGIN_FAILURE, { reason: "not-configured" });
+      this.recordEvent(EVENT_LOGIN_END);
       core.info(
         "FlakeHub is disabled because the workflow is misconfigured. Please make sure that `id-token: write` and `contents: read` are set for this step's (or job's) permissions so that GitHub Actions provides OIDC token endpoints."
       );
@@ -100518,9 +100523,9 @@ var NixInstallerAction = class extends DetSysAction {
       return;
     }
     core.startGroup("Logging in to FlakeHub");
-    this.recordEvent(EVENT_LOGIN_TO_FLAKEHUB);
     try {
       await exec.exec(`determinate-nixd`, ["login", "github-action"]);
+      this.recordEvent(EVENT_LOGIN_SUCCESS);
     } catch (e) {
       core.warning(`FlakeHub Login failure: ${stringifyError(e)}`);
       this.recordEvent(EVENT_LOGIN_FAILURE, {
@@ -100528,6 +100533,7 @@ var NixInstallerAction = class extends DetSysAction {
         exception: stringifyError(e)
       });
     }
+    this.recordEvent(EVENT_LOGIN_END);
     core.endGroup();
   }
   async executeUninstall() {


### PR DESCRIPTION
##### Description

This PR restructures FlakeHub login events:

* All logins begin with a `start` event.
* Then, they proceed to either `success` or `failure`.
* Finally, an `end` is recorded.

As a future maintenance note: we need to make sure that `end` is recorded in all code paths.

##### Checklist

- [ ] Tested changes against a test repository
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] (If this PR is for a release) Updated README to point to the new tag (leave unchecked if not applicable)
